### PR TITLE
mock: add a matcher for ANY valid UUID

### DIFF
--- a/xivo_test_helpers/mock.py
+++ b/xivo_test_helpers/mock.py
@@ -1,0 +1,20 @@
+# Copyright 2017 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0+
+
+import uuid
+
+
+class _UUIDMatcher(object):
+
+    def __eq__(self, other):
+        try:
+            uuid.UUID(other)
+            return True
+        except:
+            return False
+
+    def __ne__(self, other):
+        return not self == other
+
+
+ANY_UUID = _UUIDMatcher()


### PR DESCRIPTION
This pull request adds a matcher similar to mock.ANY that will match any valid UUID

ANY_UUID == 'foobar' => False
ANY_UUID == '97b72e89-b941-465b-a861-2178e8aa3f8a' => True

I've been adding code similar to this in almost every service I've been working on in the last few months