### PR TITLE
MockUserToken always set metadata[uuid]

### DIFF
--- a/xivo_test_helpers/auth.py
+++ b/xivo_test_helpers/auth.py
@@ -89,6 +89,7 @@ class MockUserToken(object):
         self.auth_id = user_uuid
         self.wazo_uuid = wazo_uuid or str(uuid.uuid4())
         self.metadata = metadata or {}
+        self.metadata.setdefault("uuid", user_uuid)
 
     def to_dict(self):
         return {

--- a/xivo_test_helpers/auth.py
+++ b/xivo_test_helpers/auth.py
@@ -89,7 +89,7 @@ class MockUserToken(object):
         self.auth_id = user_uuid
         self.wazo_uuid = wazo_uuid or str(uuid.uuid4())
         self.metadata = metadata or {}
-        self.metadata.setdefault("uuid", user_uuid)
+        self.metadata.setdefault('uuid', user_uuid)
 
     def to_dict(self):
         return {


### PR DESCRIPTION
1c8af6353134ea527d682edec52750ac889ae0db have make metadata[uuid]
mandatory on the mocked server. We should do the same for the client side.